### PR TITLE
fix: fix the code terms

### DIFF
--- a/components/ChatMessage.jsx
+++ b/components/ChatMessage.jsx
@@ -3,10 +3,10 @@ import { AUTHOR_GPT } from "utils/constants";
 import { CodeBlock } from "./codeblock";
 
 const regExCodeBlock = /```([\s\S]*?)```/g;
-const regExCodeTerm = /`([\s\S]*?)`/;
+const regExCodeTerm = /`([\s\S]*?)`/g;
 
 const displayResponse = (chat) => {
-  if (chat.message.includes("```") && AUTHOR_GPT === chat.author) {
+  if (AUTHOR_GPT === chat.author) {
     /**
      * function for getting the [codes term] from chat message and codeBlocks
      *
@@ -50,8 +50,8 @@ const ChatMessage = ({ chat }) => {
   return (
     <div
       className={`${
-        AUTHOR_GPT === chat.author ? "bg-gray-300 text-gray-800" : null
-      } bg-gray-100 p-2 rounded-xl text-md text-black`}
+        AUTHOR_GPT === chat.author && "bg-gray-300 text-gray-800"
+      } bg-gray-100 p-2 rounded-xl text-md text-black whitespace-pre-line`}
     >
       {displayResponse(chat)}
     </div>


### PR DESCRIPTION
code term not working if it is only code terms on response ,not with code blocks

\n not  working in plain jsx
![not working the reserve world for codes](https://user-images.githubusercontent.com/88084088/227920456-f5e58944-aab7-4f93-8814-e3b3014787c1.png)
![fix](https://user-images.githubusercontent.com/88084088/227920463-acece746-6064-4d5b-aa3f-afa4c1254f43.png)
